### PR TITLE
remove the 0.5 scaling term

### DIFF
--- a/pyhmc/_hmc.pyx
+++ b/pyhmc/_hmc.pyx
@@ -106,7 +106,7 @@ def hmc_main_loop(fun, double[::1] x, args, double[::1] p,
                     # p = p - direction*epsilon.*feval(gradf, x, varargin{:});
                     logp, grad = fun(asarray(x), *args)
                     for i in range(n_params):
-                        p[i] +=  direction * 0.5 * epsilon * grad[i]
+                        p[i] +=  direction * epsilon * grad[i]
                     for i in range(n_params):
                         x[i] += direction * epsilon * p[i]
 


### PR DESCRIPTION
Remove the 0.5 scaling term in the full leapfrog step.
The original paper of "Neal's MCMC using Hamiltoniann" (http://www.mcmchandbook.net/HandbookChapter5.pdf, page 125) does not contain this term. 

Also, both of the following link do not contain the 0.5 scaling term
line 357 of https://github.com/koepsell/pyhmc/blob/master/hmc2.py
line 199 of https://github.com/koepsell/pyhmc/blob/master/hmc2.m